### PR TITLE
Add macOS compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ import PackageDescription
 let package = Package(
     name: "SwiftUIFeatureBugReport",
     platforms: [
-        .iOS(.v17)
+        .iOS(.v17),
+        .macOS(.v14)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Feedback SDK for SwiftUI
 
-A simple, lightweight SwiftUI package for collecting user feedback (bug reports and feature requests) directly in your iOS app using GitHub Issues as the backend.
+A simple, lightweight SwiftUI package for collecting user feedback (bug reports and feature requests) directly in your iOS or macOS app using GitHub Issues as the backend.
 
 ## Features
 
@@ -181,7 +181,7 @@ User's feedback description
 ---
 **Device Information:**
 Device: iPhone15,2  
-iOS Version: 17.0
+OS Version: 17.0
 App Version: 1.0.0 (1)
 Device ID: ABC-123-DEF
 
@@ -199,7 +199,7 @@ Device ID: ABC-123-DEF
 // Override device info collection
 let customDeviceInfo = """
 Device: \(DeviceInfo.getDeviceModel())
-OS: \(DeviceInfo.getIOSVersion()) 
+OS: \(DeviceInfo.getOSVersion()) 
 App: \(DeviceInfo.getAppVersion())
 Custom Field: \(yourCustomData)
 """
@@ -300,7 +300,7 @@ labels: bug, user-submitted
 
 **Device Info:**
 - Device: 
-- iOS Version: 
+- OS Version: 
 - App Version: 
 
 **Description:**
@@ -348,5 +348,6 @@ print("User has voted on: \(votingService.getVotedIssues())")
 ## Requirements
 
 - iOS 17.0+
+- macOS 14.0+
 - Xcode 15.0+
 - Swift 5.9+

--- a/Sources/SwiftUIFeatureBugReport/Helpers/DeviceInfo.swift
+++ b/Sources/SwiftUIFeatureBugReport/Helpers/DeviceInfo.swift
@@ -5,23 +5,26 @@
 //  Created by Tom Redway on 25/09/2025.
 //
 
-import UIKit
+import Foundation
 
 public struct DeviceInfo {
+
+    private static let deviceIdentifierKey = "com.swiftuifeaturebugreport.device.identifier"
     
     /// Generate a formatted device information report for bug reports
-    @MainActor public static func generateReport() -> String {
-        
-        let device = UIDevice.current
+    public static func generateReport() -> String {
+
         let app = Bundle.main
-        
+
         let deviceModel = getDeviceModel()
+        let osVersion = getOSVersion()
+        let platformName = getPlatformName()
         let appVersion = app.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
         let buildNumber = app.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"
-        
+
         return """
         Device: \(deviceModel)
-        iOS Version: \(device.systemVersion)
+        \(platformName) Version: \(osVersion)
         App Version: \(appVersion) (\(buildNumber))
         """
     }
@@ -54,13 +57,51 @@ public struct DeviceInfo {
         Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"
     }
     
-    @MainActor public static func getIOSVersion() -> String {
-        
-        UIDevice.current.systemVersion
+    public static func getOSVersion() -> String {
+
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        return "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
     }
-    
-    @MainActor public static func getDeviceID() -> String {
-        
-        UIDevice.current.identifierForVendor?.uuidString ?? "Unknown"
+
+    @available(*, deprecated, message: "Use getOSVersion()")
+    public static func getIOSVersion() -> String {
+
+        getOSVersion()
+    }
+
+    public static func getDeviceID() -> String {
+
+        let defaults = UserDefaults.standard
+
+        if let existingID = defaults.string(forKey: deviceIdentifierKey) {
+            return existingID
+        }
+
+        let newID = UUID().uuidString
+        defaults.set(newID, forKey: deviceIdentifierKey)
+
+        return newID
+    }
+
+    private static func getPlatformName() -> String {
+        #if targetEnvironment(macCatalyst)
+        "macCatalyst"
+        #elseif os(iOS)
+        "iOS"
+        #elseif os(macOS)
+        "macOS"
+        #elseif os(tvOS)
+        "tvOS"
+        #elseif os(watchOS)
+        "watchOS"
+        #elseif os(visionOS)
+        "visionOS"
+        #elseif os(Linux)
+        "Linux"
+        #elseif os(Windows)
+        "Windows"
+        #else
+        "OS"
+        #endif
     }
 }

--- a/Sources/SwiftUIFeatureBugReport/Views/FeedbackFormView.swift
+++ b/Sources/SwiftUIFeatureBugReport/Views/FeedbackFormView.swift
@@ -86,7 +86,9 @@ public struct FeedbackFormView: View {
                     
                     TextField("Email", text: $contactEmail)
                         .textContentType(.emailAddress)
+                        #if os(iOS)
                         .textInputAutocapitalization(.never)
+                        #endif
                     
                 }, header: { Text("Contact Email (optional)") },
                         footer: { Text("To contact you for more details") })
@@ -117,13 +119,22 @@ public struct FeedbackFormView: View {
                 }
             }
             .navigationTitle("Feedback")
+            #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
+            #endif
             .toolbar {
                 
+                #if os(iOS)
                 ToolbarItem(placement: .navigationBarLeading) {
                     
                     Button("Cancel") { dismiss() }
                 }
+                #else
+                ToolbarItem(placement: .cancellationAction) {
+                    
+                    Button("Cancel") { dismiss() }
+                }
+                #endif
             }
             
             .alert("Success!", isPresented: $showSuccess) {

--- a/Sources/SwiftUIFeatureBugReport/Views/IssuesListView.swift
+++ b/Sources/SwiftUIFeatureBugReport/Views/IssuesListView.swift
@@ -102,7 +102,7 @@ public struct IssuesListView: View {
             .navigationTitle("Feedback")
             .toolbar {
                 
-                ToolbarItem(placement: .topBarTrailing) {
+                ToolbarItem(placement: toolbarTrailingPlacement) {
                     
                     Menu(content: {
                         
@@ -118,12 +118,14 @@ public struct IssuesListView: View {
                     }, label: { Image(systemName: "line.horizontal.3.decrease") })
                 }
                 
+                #if os(iOS)
                 if #available(iOS 26, *) {
                     
                     ToolbarSpacer(.fixed, placement: .topBarTrailing)
                 }
+                #endif
                 
-                ToolbarItem(placement: .topBarTrailing) {
+                ToolbarItem(placement: toolbarTrailingPlacement) {
                     
                     Button(action: { showingFeedbackForm = true }, label: { Image(systemName: "plus") })
                 }
@@ -455,7 +457,7 @@ public struct IssueDetailsView: View {
             //only show this if the corerct user
             if ownershipService.ownsIssue(issue.number) {
                 
-                ToolbarItem(placement: .topBarTrailing) {
+                ToolbarItem(placement: toolbarTrailingPlacement) {
                     
                     Menu(content: {
                         
@@ -568,4 +570,12 @@ public struct IssueDetailsView: View {
         
         return displayFormatter.localizedString(for: date, relativeTo: Date())
     }
+}
+
+private var toolbarTrailingPlacement: ToolbarItemPlacement {
+    #if os(iOS)
+    .topBarTrailing
+    #else
+    .primaryAction
+    #endif
 }


### PR DESCRIPTION
This PR introduces macOS compatibility.

**Key Changes**

- Add macOS platform support in Package.swift
- Update README to reflect iOS + macOS compatibility

**Refactor DeviceInfo:**

- Replace UIKit usage with Foundation
- Introduce platform-agnostic OS version retrieval
- Add dynamic platform name detection (iOS, macOS, tvOS, etc.)
- Implement persistent device identifier using UserDefaults

**Updat UI code to handle platform-specific differences:**

- Conditional modifiers for iOS-only APIs (e.g. textInputAutocapitalization)
- Toolbar placement adjustments for macOS compatibility